### PR TITLE
Make SLR happy about environment in media-sound/cantata-9999

### DIFF
--- a/media-sound/cantata/cantata-9999.ebuild
+++ b/media-sound/cantata/cantata-9999.ebuild
@@ -5,7 +5,8 @@
 EAPI=5
 KDE_REQUIRED="optional"
 PLOCALES="cs de en_GB es hu ko pl ru zh_CN"
-inherit kde4-base l10n subversion
+KDE_SCM="svn"
+inherit kde4-base l10n
 
 DESCRIPTION="A featureful and configurable Qt4 client for the music player daemon (MPD)"
 HOMEPAGE="https://code.google.com/p/cantata/"


### PR DESCRIPTION
It seems like kde4-base.eclass touches EGIT_ vriables even when KDE_SCM
is not set, thus smart-live-rebuild was thinking that cantata is Git
based and was triggering its rebuild every time
